### PR TITLE
Add ApiResponse integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.github export-ignore
+/tests export-ignore
+/vendor export-ignore
+/vendor-bin export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
                     coverage: "none"
                     ini-values: "memory_limit=-1"
                     php-version: "${{ matrix.php }}"
-                    tools: "composer, composer-normalize"
+                    tools: "composer"
 
             -   name: Display versions
                 run: |
@@ -34,16 +34,8 @@ jobs:
             -   name: Install Composer
                 run: composer install --optimize-autoloader --classmap-authoritative --no-interaction
 
-            -   name: Composer Normalize
-                run: composer-normalize --indent-style tab --indent-size 1 --dry-run --ansi
+            -   name: Run Linters
+                run: composer run-script lint
 
-            -   name: PHP CS Fixer
-                run: "./vendor/bin/php-cs-fixer fix --diff --config vendor-bin/cs-fixer/vendor/21torr/php-cs-fixer/.php-cs-fixer.dist.php --dry-run --no-interaction --ansi --format=checkstyle"
-                env:
-                    PHP_CS_FIXER_IGNORE_ENV: 1
-
-            -   name: PHPStan
-                run: "./vendor/bin/phpstan analyze -c vendor-bin/test/vendor/21torr/php-cs/phpstan/lib.neon . --ansi"
-
-            -   name: PHPUnit
-                run: "./vendor/bin/phpunit"
+            -   name: Run Tests
+                run: composer run-script test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.2.0 (unreleased)
+=====
+
+* (feature) Add `ApiResponse`.
+
+
 2.1.0
 =====
 

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,14 @@
 		],
 		"post-update-cmd": [
 			"@composer bin all update --ansi"
+		],
+		"lint": [
+			"@composer bin c-norm normalize \"$(pwd)/composer.json\" --indent-style tab --indent-size 1 --dry-run --ansi",
+			"php-cs-fixer fix --diff --config vendor-bin/cs-fixer/vendor/21torr/php-cs-fixer/.php-cs-fixer.dist.php --dry-run --no-interaction --ansi"
+		],
+		"test": [
+			"phpunit",
+			"phpstan analyze -c phpstan.neon . --ansi"
 		]
 	}
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,4 +11,4 @@ services:
             - ../src/Exception
             - ../src/Pagination/Paginat*
             - ../src/Route
-            - ../src/TorrRadBundle.php}
+            - ../src/TorrRadBundle.php

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,4 +5,10 @@ services:
 
     Torr\Rad\:
         resource: ../src/*
-        exclude: ../src/{Entity,Exception,Pagination/Paginat*,TorrRadBundle.php}
+        exclude:
+            - ../src/Api
+            - ../src/Entity
+            - ../src/Exception
+            - ../src/Pagination/Paginat*
+            - ../src/Route
+            - ../src/TorrRadBundle.php}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,2 @@
+includes:
+    - vendor-bin/test/vendor/21torr/php-cs/phpstan/lib.neon

--- a/src/Api/ApiResponse.php
+++ b/src/Api/ApiResponse.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Rad\Api;
+
+class ApiResponse
+{
+	public readonly int $statusCode;
+
+	public function __construct (
+		private readonly bool $ok,
+		private readonly mixed $data = null,
+		private readonly ?string $error = null,
+		?int $statusCode = null,
+	)
+	{
+		$this->statusCode = $statusCode ?? ($ok ? 200 : 400);
+	}
+
+
+	/**
+	 */
+	public function toArray () : array
+	{
+		return \array_filter(
+			[
+				"ok" => $this->ok,
+				"data" => $this->data,
+				"error" => $this->error,
+			],
+			static fn (mixed $value) => null !== $value,
+		);
+	}
+}

--- a/src/Listener/ControllerResponseListener.php
+++ b/src/Listener/ControllerResponseListener.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Rad\Listener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Torr\Rad\Api\ApiResponse;
+
+#[AsEventListener(KernelEvents::VIEW, "onView")]
+final class ControllerResponseListener
+{
+	/**
+	 */
+	public function onView (ViewEvent $event) : void
+	{
+		$result = $event->getControllerResult();
+
+		if ($result instanceof ApiResponse)
+		{
+			$event->setResponse(
+				new JsonResponse(
+					$result->toArray(),
+					$result->statusCode,
+				),
+			);
+		}
+	}
+}

--- a/src/Listener/ControllerResponseListener.php
+++ b/src/Listener/ControllerResponseListener.php
@@ -8,11 +8,11 @@ use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Torr\Rad\Api\ApiResponse;
 
-#[AsEventListener(KernelEvents::VIEW, "onView")]
 final class ControllerResponseListener
 {
 	/**
 	 */
+	#[AsEventListener(KernelEvents::VIEW)]
 	public function onView (ViewEvent $event) : void
 	{
 		$result = $event->getControllerResult();

--- a/tests/Api/ApiResponseTest.php
+++ b/tests/Api/ApiResponseTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Torr\Rad\Api;
+
+use Torr\Rad\Api\ApiResponse;
+use PHPUnit\Framework\TestCase;
+
+class ApiResponseTest extends TestCase
+{
+	/**
+	 *
+	 */
+	public function testMinimal () : void
+	{
+		$apiResponse = new ApiResponse(false);
+
+		self::assertEquals([
+			"ok" => false,
+		], $apiResponse->toArray());
+	}
+
+	/**
+	 *
+	 */
+	public function testMaximal () : void
+	{
+		$apiResponse = new ApiResponse(
+			true,
+			["o" => "hai"],
+			"error message",
+		);
+
+		self::assertEquals([
+			"ok" => true,
+			"data" => ["o" => "hai"],
+			"error" => "error message",
+		], $apiResponse->toArray());
+	}
+
+	/**
+	 *
+	 */
+	public function provideStatusCode () : iterable
+	{
+		yield [200, new ApiResponse(true)];
+		yield [400, new ApiResponse(false)];
+		yield [418, new ApiResponse(false, statusCode: 418)];
+	}
+
+	/**
+	 * @dataProvider provideStatusCode
+	 */
+	public function testStatusCode (int $expected, ApiResponse $apiResponse) : void
+	{
+		self::assertSame($expected, $apiResponse->toResponse()->getStatusCode());
+	}
+}

--- a/tests/Api/ApiResponseTest.php
+++ b/tests/Api/ApiResponseTest.php
@@ -36,22 +36,4 @@ class ApiResponseTest extends TestCase
 			"error" => "error message",
 		], $apiResponse->toArray());
 	}
-
-	/**
-	 *
-	 */
-	public function provideStatusCode () : iterable
-	{
-		yield [200, new ApiResponse(true)];
-		yield [400, new ApiResponse(false)];
-		yield [418, new ApiResponse(false, statusCode: 418)];
-	}
-
-	/**
-	 * @dataProvider provideStatusCode
-	 */
-	public function testStatusCode (int $expected, ApiResponse $apiResponse) : void
-	{
-		self::assertSame($expected, $apiResponse->toResponse()->getStatusCode());
-	}
 }

--- a/tests/Listener/ControllerResponseListenerTest.php
+++ b/tests/Listener/ControllerResponseListenerTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Torr\Rad\Listener;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Torr\Rad\Api\ApiResponse;
+use Torr\Rad\Listener\ControllerResponseListener;
+use PHPUnit\Framework\TestCase;
+
+class ControllerResponseListenerTest extends TestCase
+{
+	/**
+	 *
+	 */
+	public function testIntegration () : void
+	{
+		$event = $this->createEvent(new ApiResponse(true));
+
+		$listener = new ControllerResponseListener();
+		$listener->onView($event);
+
+		self::assertInstanceOf(JsonResponse::class, $event->getResponse());
+	}
+
+	/**
+	 *
+	 */
+	public function testIntegrationWithOtherResult () : void
+	{
+		$event = $this->createEvent(11);
+
+		$listener = new ControllerResponseListener();
+		$listener->onView($event);
+
+		self::assertNull($event->getResponse());
+	}
+
+
+	/**
+	 *
+	 */
+	public function provideStatusCode () : iterable
+	{
+		yield [200, new ApiResponse(true)];
+		yield [400, new ApiResponse(false)];
+		yield [418, new ApiResponse(false, statusCode: 418)];
+	}
+
+	/**
+	 * @dataProvider provideStatusCode
+	 */
+	public function testStatusCode (int $expectedStatusCode, ApiResponse $apiResponse) : void
+	{
+		$event = $this->createEvent($apiResponse);
+
+		$listener = new ControllerResponseListener();
+		$listener->onView($event);
+
+		$response = $event->getResponse();
+		self::assertInstanceOf(JsonResponse::class, $response);;
+		self::assertSame($expectedStatusCode, $response->getStatusCode());
+	}
+
+	/**
+	 *
+	 */
+	private function createEvent (mixed $controllerResult) : ViewEvent
+	{
+		return new ViewEvent(
+			$this->createMock(KernelInterface::class),
+			new Request(),
+			HttpKernelInterface::MAIN_REQUEST,
+			$controllerResult,
+		);
+	}
+}

--- a/vendor-bin/c-norm/composer.json
+++ b/vendor-bin/c-norm/composer.json
@@ -1,0 +1,10 @@
+{
+    "require-dev": {
+        "ergebnis/composer-normalize": "^2.28"
+    },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        }
+    }
+}


### PR DESCRIPTION
The usage of the api response is pretty easy:


```php
class MyController extends BaseController
{
	public function action () : ApiResponse
	{
		return new ApiResponse(true, ["o" => "hai"]);
	}
}
```