### PR TITLE
Add `DoctrineChangeChecker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.5.0
+=====
+
+* (feature) Add `DoctrineChangeChecker`, to check for content changes in the unit of work.
+
+
 2.4.0
 =====
 

--- a/src/DependencyInjection/RemoveOptionalServicesCompilerPass.php
+++ b/src/DependencyInjection/RemoveOptionalServicesCompilerPass.php
@@ -2,9 +2,11 @@
 
 namespace Torr\Rad\DependencyInjection;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Security\Core\Authorization\Voter\RoleHierarchyVoter;
+use Torr\Rad\Doctrine\DoctrineChangeChecker;
 use Torr\Rad\Security\AbilitiesVoter;
 
 final class RemoveOptionalServicesCompilerPass implements CompilerPassInterface
@@ -17,6 +19,11 @@ final class RemoveOptionalServicesCompilerPass implements CompilerPassInterface
 		if (!\class_exists(RoleHierarchyVoter::class))
 		{
 			$container->removeDefinition(AbilitiesVoter::class);
+		}
+
+		if (!\class_exists(EntityManagerInterface::class))
+		{
+			$container->removeDefinition(DoctrineChangeChecker::class);
 		}
 	}
 }

--- a/src/Doctrine/DoctrineChangeChecker.php
+++ b/src/Doctrine/DoctrineChangeChecker.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Rad\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class DoctrineChangeChecker
+{
+	/**
+	 */
+	public function __construct (
+		private EntityManagerInterface $entityManager,
+	) {}
+
+
+	/**
+	 * Determines whether any content in the entities (or the entities themselves)
+	 * has changed. Only changing "timeModified" doesn't count as content change.
+	 *
+	 * @api
+	 */
+	public function hasContentChanged () : bool
+	{
+		$unitOfWork = $this->entityManager->getUnitOfWork();
+		$unitOfWork->computeChangeSets();
+
+		// If any entity was added / removed, something changed, so early exit
+		if (
+			\count($unitOfWork->getScheduledEntityInsertions()) > 0
+			|| \count($unitOfWork->getScheduledEntityDeletions()) > 0
+			|| \count($unitOfWork->getScheduledCollectionUpdates()) > 0
+			|| \count($unitOfWork->getScheduledCollectionDeletions()) > 0
+		)
+		{
+			return true;
+		}
+
+		foreach ($unitOfWork->getScheduledEntityUpdates() as $entity)
+		{
+			$changes = $unitOfWork->getEntityChangeSet($entity);
+
+			// if only timeModified changed, then nothing in the content changed
+			if (1 === \count($changes) && "timeModified" === \array_key_first($changes))
+			{
+				continue;
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/tests/Doctrine/DoctrineChangeCheckerTest.php
+++ b/tests/Doctrine/DoctrineChangeCheckerTest.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Torr\Rad\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\UnitOfWork;
+use Torr\Rad\Doctrine\DoctrineChangeChecker;
+use PHPUnit\Framework\TestCase;
+
+class DoctrineChangeCheckerTest extends TestCase
+{
+	/**
+	 *
+	 */
+	public static function provideLargeEntityChanges () : iterable
+	{
+		yield "empty" => [
+			false,
+		];
+
+		yield "entity-insertions" => [
+			true,
+			["not empty"],
+		];
+
+		yield "entity-deletions" => [
+			true,
+			[],
+			["not empty"],
+		];
+
+		yield "collection-updates" => [
+			true,
+			[],
+			[],
+			["not empty"],
+		];
+
+		yield "collection-deletions" => [
+			true,
+			[],
+			[],
+			[],
+			["not empty"],
+		];
+	}
+
+	/**
+	 * @dataProvider provideLargeEntityChanges
+	 */
+	public function testLargeEntityChanges (
+		bool $expected,
+		array $entityInsertions = [],
+		array $entityDeletions = [],
+		array $collectionUpdates = [],
+		array $collectionDeletions = [],
+	) : void
+	{
+		$unitOfWork = $this->createMock(UnitOfWork::class);
+
+		$unitOfWork
+			->method("getScheduledEntityInsertions")
+			->willReturn($entityInsertions);
+
+		$unitOfWork
+			->method("getScheduledEntityUpdates")
+			->willReturn([]);
+
+		$unitOfWork
+			->method("getScheduledEntityDeletions")
+			->willReturn($entityDeletions);
+
+		$unitOfWork
+			->method("getScheduledCollectionUpdates")
+			->willReturn($collectionUpdates);
+
+		$unitOfWork
+			->method("getScheduledCollectionDeletions")
+			->willReturn($collectionDeletions);
+
+		$entityManager = $this->createMock(EntityManagerInterface::class);
+		$entityManager
+			->method("getUnitOfWork")
+			->willReturn($unitOfWork);
+
+		$checker = new DoctrineChangeChecker($entityManager);
+		self::assertSame($expected, $checker->hasContentChanged());
+	}
+
+
+	public static function provideChangesets () : iterable
+	{
+		yield "only time modified" => [false, [
+			"timeModified" => [/* ... */],
+		]];
+
+		yield "other" => [true, [
+			"other" => [/* ... */],
+		]];
+
+		yield "other with time modified" => [true, [
+			"other" => [/* ... */],
+			"timeModified" => [/* ... */],
+		]];
+	}
+
+
+	/**
+	 * @dataProvider provideChangesets
+	 */
+	public function testChangesets (
+		bool $expected,
+		array $changeset,
+	) : void
+	{
+		$unitOfWork = $this->createMock(UnitOfWork::class);
+		$entity = new \stdClass();
+
+		$unitOfWork
+			->method("getScheduledEntityInsertions")
+			->willReturn([]);
+
+		$unitOfWork
+			->method("getScheduledEntityUpdates")
+			->willReturn([$entity]);
+
+		$unitOfWork
+			->method("getScheduledEntityDeletions")
+			->willReturn([]);
+
+		$unitOfWork
+			->method("getScheduledCollectionUpdates")
+			->willReturn([]);
+
+		$unitOfWork
+			->method("getScheduledCollectionDeletions")
+			->willReturn([]);
+
+		$unitOfWork
+			->method("getEntityChangeSet")
+			->with($entity)
+			->willReturn($changeset);
+
+		$entityManager = $this->createMock(EntityManagerInterface::class);
+		$entityManager
+			->method("getUnitOfWork")
+			->willReturn($unitOfWork);
+
+		$checker = new DoctrineChangeChecker($entityManager);
+		self::assertSame($expected, $checker->hasContentChanged());
+	}
+}


### PR DESCRIPTION
This is a service, that is responsible to check if anything in the entities changed except the `timeModified` time stamp.

This is useful, because now you can just finish your import, but only start following processes (like deployments) depending on whether any content changed at all.