### PR TITLE
Only ignore a single PHPStan issue for the container helper in `BaseC…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =====
 
 * (internal) Simplify types of `ArgumentBag`.
+* (internal) Only ignore a single PHPStan issue for the container helper in `BaseController`.
 
 
 3.2.0

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -23,7 +23,7 @@ abstract class BaseController extends AbstractController
 	 */
 	protected function getService (string $service) : object
 	{
-		// @phpstan-ignore-next-line
+		// @phpstan-ignore-next-line return.type (The return value is fine, PHPStan doesn't know the generics)
 		return $this->container->get($service);
 	}
 


### PR DESCRIPTION
…ontroller`